### PR TITLE
Allow the disabling of logger replacement

### DIFF
--- a/lib/logstash-logger/railtie.rb
+++ b/lib/logstash-logger/railtie.rb
@@ -18,7 +18,7 @@ module LogStashLogger
 
     logger.level = ::Logger.const_get(app.config.log_level.to_s.upcase)
 
-    app.config.logger = logger
+    app.config.logger = logger unless logger_options.disable_default_logger_replacement
   end
 
   def self.sanitize_logger_options(app, logger_options)


### PR DESCRIPTION
I want to use logstash-logger to log a good amount of events, but have found the default of just logging everything Rails giving you to be too much. I want to be able to opt-in into specific `ActiveSupport::Notifications` so the first step was to give the option to out-out of the automatic logger replacement.
